### PR TITLE
docs: add sample profile with file name matching clarification

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,15 @@ Note that `$XDG_CONFIG` will be resolved on `.git/config` because of the restric
 	path = <$XDG_CONFIG>/git-profile/<PROFILE-NAME>.gitconfig
 ```
 
+## Sample Profile
+
+To create a profile, the filename must have a leading part that matches the profile name you'll use with the `switch` command. For example, to use profile `work`, create a file at `~/.config/git-profile/work.gitconfig`:
+
+```gitconfig
+[user]
+    name = John Doe
+    email = john.doe@example.com
+[core]
+    editor = vim
+```
+


### PR DESCRIPTION
Fixes #2

Added a sample profile section to the README.md file showing:
- Example file location at `~/.config/git-profile/work.gitconfig`
- Clear explanation that filename must have leading part matching profile name
- Sample gitconfig syntax with user.name, user.email, and core.editor settings
- Uses `@example.com` domain as requested

Generated with [Claude Code](https://claude.ai/code)