### PR TITLE
feat: improve error handling with thiserror and anyhow

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+anyhow = "1.0"
 clap = { version = "4.5.39", features = ["derive"] }
 git2 = "0.20.2"
+thiserror = "1.0"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,22 @@
+use thiserror::Error;
+
+/// Errors that can occur in git-profile-rs
+#[derive(Error, Debug)]
+pub enum GitProfileError {
+    #[error("Failed to open git repository: {0}")]
+    RepositoryOpen(#[from] git2::Error),
+    
+    #[error("Failed to access git configuration")]
+    ConfigAccess(#[source] git2::Error),
+    
+    #[error("Environment variable error: {variable}")]
+    Environment { variable: String },
+    
+    #[error("Profile path error: {path}")]
+    ProfilePath { path: String },
+    
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+pub type Result<T> = std::result::Result<T, GitProfileError>;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,36 +1,41 @@
 mod cli;
+mod error;
 mod profile;
 
+use anyhow::Context;
 use clap::Parser;
 use cli::{Cli, Commands};
 use crate::profile::git_config_git2::Git2Config;
 
 fn main() {
+    if let Err(e) = run() {
+        eprintln!("Error: {:#}", e);
+        std::process::exit(1);
+    }
+}
+
+fn run() -> anyhow::Result<()> {
     let cli = Cli::parse();
     match cli.command {
         Commands::Switch { profile_name, global } => {
             let open_config = if global { Git2Config::open_global } else { Git2Config::open_local };
-            let mut config = match open_config() {
-                Ok(config) => config,
-                Err(e) => {
-                    eprintln!("Error opening global config: {}", e);
-                    std::process::exit(1);
-                }
-            };
-            let profile_dir = get_profile_dir();
-            if let Err(e) = profile::switch::switch(&profile_name, global, &profile_dir, &mut config) {
-                eprintln!("Error: {}", e);
-                std::process::exit(1);
-            }
+            let mut config = open_config()
+                .with_context(|| format!("Failed to open {} git configuration", if global { "global" } else { "local" }))?;
+            let profile_dir = get_profile_dir()?;
+            profile::switch::switch(&profile_name, global, &profile_dir, &mut config)
+                .with_context(|| format!("Failed to switch to profile '{}'", profile_name))?;
         }
     }
+    Ok(())
 }
 
-fn get_profile_dir() -> String {
+fn get_profile_dir() -> anyhow::Result<String> {
     let xdg_config = if let Ok(xdg_config) = std::env::var("XDG_CONFIG_HOME") {
         xdg_config
     } else {
-        format!("{}/.config", std::env::var("HOME").unwrap())
+        let home = std::env::var("HOME")
+            .with_context(|| "HOME environment variable is not set")?;
+        format!("{}/.config", home)
     };
-    format!("{}/git-profile", xdg_config)
+    Ok(format!("{}/git-profile", xdg_config))
 }

--- a/src/profile/git_config.rs
+++ b/src/profile/git_config.rs
@@ -1,3 +1,5 @@
+use crate::error::Result;
+
 pub trait GitConfig {
-    fn set_include_path(&mut self, path: &str) -> Result<(), Box<dyn std::error::Error>>;
+    fn set_include_path(&mut self, path: &str) -> Result<()>;
 }

--- a/src/profile/git_config_git2.rs
+++ b/src/profile/git_config_git2.rs
@@ -1,27 +1,29 @@
 use git2::{Config, Repository};
 use super::git_config::GitConfig;
+use crate::error::{GitProfileError, Result};
 
 pub struct Git2Config {
     config: Config,
 }
 
 impl Git2Config {
-    pub fn open_global() -> Result<Self, Box<dyn std::error::Error>> {
-        Ok(Git2Config {
-            config: Config::open_default()?,
-        })
+    pub fn open_global() -> Result<Self> {
+        let config = Config::open_default()
+            .map_err(|e| GitProfileError::ConfigAccess(e))?;
+        Ok(Git2Config { config })
     }
-    pub fn open_local() -> Result<Self, Box<dyn std::error::Error>> {
+    pub fn open_local() -> Result<Self> {
         let repo = Repository::open(".")?;
-        Ok(Git2Config {
-            config: repo.config()?,
-        })
+        let config = repo.config()
+            .map_err(|e| GitProfileError::ConfigAccess(e))?;
+        Ok(Git2Config { config })
     }
 }
 
 impl GitConfig for Git2Config {
-    fn set_include_path(&mut self, path: &str) -> Result<(), Box<dyn std::error::Error>> {
-        self.config.set_str("include.path", path)?;
+    fn set_include_path(&mut self, path: &str) -> Result<()> {
+        self.config.set_str("include.path", path)
+            .map_err(|e| GitProfileError::ConfigAccess(e))?;
         Ok(())
     }
 }

--- a/src/profile/switch.rs
+++ b/src/profile/switch.rs
@@ -5,7 +5,7 @@ pub fn switch<T: GitConfig>(
     global: bool,
     profile_dir: &str,
     config: &mut T,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> anyhow::Result<()> {
     let profile_path = format!("{}/{}.gitconfig", profile_dir, profile_name);
     config.set_include_path(&profile_path)?;
     if global {
@@ -39,7 +39,7 @@ mod tests {
     }
 
     impl GitConfig for MockGitConfig {
-        fn set_include_path(&mut self, path: &str) -> Result<(), Box<dyn std::error::Error>> {
+        fn set_include_path(&mut self, path: &str) -> crate::error::Result<()> {
             self.config.insert("include.path".to_string(), path.to_string());
             Ok(())
         }


### PR DESCRIPTION
This PR improves error handling throughout the codebase by implementing thiserror and anyhow for better error management.

## Changes
- Added thiserror and anyhow dependencies
- Created custom GitProfileError enum with specific error variants
- Replaced Box<dyn std::error::Error> with structured error types
- Added error context for better debugging information
- Updated all function signatures to use new error types

Closes #4

Generated with [Claude Code](https://claude.ai/code)