### PR TITLE
Improve error handling with custom error types

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,7 @@ The tool modifies Git configuration by adding include paths to either local repo
 - **Build**: `cargo build`
 - **Run**: `cargo run -- switch <PROFILE-NAME> [--global]`
 - **Check code**: `cargo clippy`
+- **Check formatting**: `cargo fmt --check` (run before committing)
 - **Run tests**: `cargo test`
 - **Test switching**: `cargo run -- switch sample` then verify with `git config user.name` and `git config user.email`
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,6 +53,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+
+[[package]]
 name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -157,8 +163,10 @@ dependencies = [
 name = "git-profile-rs"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "clap",
  "git2",
+ "thiserror",
 ]
 
 [[package]]
@@ -492,6 +500,26 @@ name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+anyhow = "1.0"
 clap = { version = "4.5.39", features = ["derive"] }
 git2 = "0.20.2"
+thiserror = "1.0"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,20 @@
+use thiserror::Error;
+
+/// Errors that can occur in git-profile-rs
+#[derive(Error, Debug)]
+pub enum GitProfileError {
+    #[error("Failed to open git repository: {0}")]
+    RepositoryOpen(#[from] git2::Error),
+    
+    #[error("Failed to access git configuration")]
+    ConfigAccess(#[source] git2::Error),
+    
+    #[error("Environment variable error: {variable}")]
+    Environment { variable: String },
+    
+    #[error("Profile path error: {path}")]
+    ProfilePath { path: String },
+    
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,16 +5,16 @@ use thiserror::Error;
 pub enum GitProfileError {
     #[error("Failed to open git repository: {0}")]
     RepositoryOpen(#[from] git2::Error),
-    
+
     #[error("Failed to access git configuration")]
     ConfigAccess(#[source] git2::Error),
-    
+
     #[error("Environment variable error: {variable}")]
     Environment { variable: String },
-    
+
     #[error("Profile path error: {path}")]
     ProfilePath { path: String },
-    
+
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,8 +2,8 @@ mod cli;
 mod error;
 mod profile;
 
-use anyhow::Context;
 use crate::profile::git_config_git2::Git2Config;
+use anyhow::Context;
 use clap::Parser;
 use cli::{Cli, Commands};
 
@@ -19,8 +19,12 @@ fn main() -> anyhow::Result<()> {
             } else {
                 Git2Config::open_local
             };
-            let mut config = open_config()
-                .with_context(|| format!("Failed to open {} git configuration", if global { "global" } else { "local" }))?;
+            let mut config = open_config().with_context(|| {
+                format!(
+                    "Failed to open {} git configuration",
+                    if global { "global" } else { "local" }
+                )
+            })?;
             let profile_dir = get_profile_dir()?;
             profile::switch::switch(&profile_name, global, &profile_dir, &mut config)
                 .with_context(|| format!("Failed to switch to profile '{}'", profile_name))?;
@@ -33,9 +37,9 @@ fn get_profile_dir() -> Result<String, crate::error::GitProfileError> {
     let xdg_config = if let Ok(xdg_config) = std::env::var("XDG_CONFIG_HOME") {
         xdg_config
     } else {
-        let home = std::env::var("HOME")
-            .map_err(|_| crate::error::GitProfileError::Environment { 
-                variable: "HOME".to_string() 
+        let home =
+            std::env::var("HOME").map_err(|_| crate::error::GitProfileError::Environment {
+                variable: "HOME".to_string(),
             })?;
         format!("{}/.config", home)
     };

--- a/src/profile/git_config.rs
+++ b/src/profile/git_config.rs
@@ -1,3 +1,5 @@
+use crate::error::GitProfileError;
+
 pub trait GitConfig {
-    fn set_include_path(&mut self, path: &str) -> Result<(), Box<dyn std::error::Error>>;
+    fn set_include_path(&mut self, path: &str) -> Result<(), GitProfileError>;
 }

--- a/src/profile/git_config_git2.rs
+++ b/src/profile/git_config_git2.rs
@@ -1,4 +1,5 @@
 use super::git_config::GitConfig;
+use crate::error::GitProfileError;
 use git2::{Config, Repository};
 
 pub struct Git2Config {
@@ -6,22 +7,23 @@ pub struct Git2Config {
 }
 
 impl Git2Config {
-    pub fn open_global() -> Result<Self, Box<dyn std::error::Error>> {
-        Ok(Git2Config {
-            config: Config::open_default()?,
-        })
+    pub fn open_global() -> Result<Self, GitProfileError> {
+        let config = Config::open_default()
+            .map_err(GitProfileError::ConfigAccess)?;
+        Ok(Git2Config { config })
     }
-    pub fn open_local() -> Result<Self, Box<dyn std::error::Error>> {
+    pub fn open_local() -> Result<Self, GitProfileError> {
         let repo = Repository::open(".")?;
-        Ok(Git2Config {
-            config: repo.config()?,
-        })
+        let config = repo.config()
+            .map_err(GitProfileError::ConfigAccess)?;
+        Ok(Git2Config { config })
     }
 }
 
 impl GitConfig for Git2Config {
-    fn set_include_path(&mut self, path: &str) -> Result<(), Box<dyn std::error::Error>> {
-        self.config.set_str("include.path", path)?;
+    fn set_include_path(&mut self, path: &str) -> Result<(), GitProfileError> {
+        self.config.set_str("include.path", path)
+            .map_err(GitProfileError::ConfigAccess)?;
         Ok(())
     }
 }

--- a/src/profile/git_config_git2.rs
+++ b/src/profile/git_config_git2.rs
@@ -8,21 +8,20 @@ pub struct Git2Config {
 
 impl Git2Config {
     pub fn open_global() -> Result<Self, GitProfileError> {
-        let config = Config::open_default()
-            .map_err(GitProfileError::ConfigAccess)?;
+        let config = Config::open_default().map_err(GitProfileError::ConfigAccess)?;
         Ok(Git2Config { config })
     }
     pub fn open_local() -> Result<Self, GitProfileError> {
         let repo = Repository::open(".")?;
-        let config = repo.config()
-            .map_err(GitProfileError::ConfigAccess)?;
+        let config = repo.config().map_err(GitProfileError::ConfigAccess)?;
         Ok(Git2Config { config })
     }
 }
 
 impl GitConfig for Git2Config {
     fn set_include_path(&mut self, path: &str) -> Result<(), GitProfileError> {
-        self.config.set_str("include.path", path)
+        self.config
+            .set_str("include.path", path)
             .map_err(GitProfileError::ConfigAccess)?;
         Ok(())
     }

--- a/src/profile/switch.rs
+++ b/src/profile/switch.rs
@@ -5,7 +5,7 @@ pub fn switch<T: GitConfig>(
     global: bool,
     profile_dir: &str,
     config: &mut T,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> anyhow::Result<()> {
     let profile_path = format!("{}/{}.gitconfig", profile_dir, profile_name);
     config.set_include_path(&profile_path)?;
     if global {
@@ -38,7 +38,7 @@ mod tests {
     }
 
     impl GitConfig for MockGitConfig {
-        fn set_include_path(&mut self, path: &str) -> Result<(), Box<dyn std::error::Error>> {
+        fn set_include_path(&mut self, path: &str) -> Result<(), crate::error::GitProfileError> {
             self.config
                 .insert("include.path".to_string(), path.to_string());
             Ok(())

--- a/src/profile/switch.rs
+++ b/src/profile/switch.rs
@@ -1,13 +1,14 @@
-use crate::profile::git_config::GitConfig;
 use crate::error::GitProfileError;
+use crate::profile::git_config::GitConfig;
 
 fn validate_profile_name(profile_name: &str) -> Result<(), GitProfileError> {
-    if profile_name.is_empty() ||
-       profile_name.contains('/') || 
-       profile_name.contains('\\') || 
-       profile_name.contains('\0') || 
-       profile_name == "." || 
-       profile_name == ".." {
+    if profile_name.is_empty()
+        || profile_name.contains('/')
+        || profile_name.contains('\\')
+        || profile_name.contains('\0')
+        || profile_name == "."
+        || profile_name == ".."
+    {
         return Err(GitProfileError::ProfilePath {
             path: profile_name.to_string(),
         });
@@ -100,7 +101,7 @@ mod tests {
         assert!(validate_profile_name("personal").is_ok());
         assert!(validate_profile_name("project-123").is_ok());
         assert!(validate_profile_name("my_profile").is_ok());
-        
+
         // Invalid profile names
         assert!(validate_profile_name("").is_err());
         assert!(validate_profile_name("invalid/profile").is_err());
@@ -113,27 +114,27 @@ mod tests {
     #[test]
     fn test_switch_with_invalid_profile_names() {
         let mut mock_config = MockGitConfig::new();
-        
+
         // Test empty profile name
         let result = switch("", false, "/test/config", &mut mock_config);
         assert!(result.is_err());
-        
+
         // Test profile name with forward slash
         let result = switch("invalid/profile", false, "/test/config", &mut mock_config);
         assert!(result.is_err());
-        
+
         // Test profile name with backslash
         let result = switch("invalid\\profile", false, "/test/config", &mut mock_config);
         assert!(result.is_err());
-        
+
         // Test profile name with null character
         let result = switch("invalid\0profile", false, "/test/config", &mut mock_config);
         assert!(result.is_err());
-        
+
         // Test "." as profile name
         let result = switch(".", false, "/test/config", &mut mock_config);
         assert!(result.is_err());
-        
+
         // Test ".." as profile name
         let result = switch("..", false, "/test/config", &mut mock_config);
         assert!(result.is_err());

--- a/src/profile/switch.rs
+++ b/src/profile/switch.rs
@@ -2,14 +2,8 @@ use crate::profile::git_config::GitConfig;
 use crate::error::GitProfileError;
 
 fn validate_profile_name(profile_name: &str) -> Result<(), GitProfileError> {
-    if profile_name.is_empty() {
-        return Err(GitProfileError::ProfilePath {
-            path: profile_name.to_string(),
-        });
-    }
-    
-    // Check for path separators and dangerous characters
-    if profile_name.contains('/') || 
+    if profile_name.is_empty() ||
+       profile_name.contains('/') || 
        profile_name.contains('\\') || 
        profile_name.contains('\0') || 
        profile_name == "." || 
@@ -18,7 +12,6 @@ fn validate_profile_name(profile_name: &str) -> Result<(), GitProfileError> {
             path: profile_name.to_string(),
         });
     }
-    
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- Implement structured error handling using `thiserror` and `anyhow`
- Add custom `GitProfileError` enum for specific error cases
- Improve error messages and context throughout the application

## Changes
- Add `thiserror` and `anyhow` dependencies
- Create `error.rs` with custom `GitProfileError` enum
- Replace generic `Box<dyn Error>` with structured error types
- Update `main()` to return `Result` instead of using `process::exit`
- Add profile name validation to prevent path traversal issues
- Use `Environment` error for missing HOME variable
- Use `ProfilePath` error for invalid profile names

## Test plan
- [x] All existing tests pass
- [x] Added new tests for profile name validation
- [x] Verified error handling for invalid profile names
- [x] No clippy warnings

Closes #4

🤖 Generated with [Claude Code](https://claude.ai/code)