### PR TITLE
Rename package from git-profile-rs to git-profile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,7 +160,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "git-profile-rs"
+name = "git-profile"
 version = "0.1.0"
 dependencies = [
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "git-profile-rs"
+name = "git-profile"
 version = "0.1.0"
 edition = "2021"
 


### PR DESCRIPTION
## Summary
- Rename Cargo.toml package name from `git-profile-rs` to `git-profile` for cleaner binary name
- Update Cargo.lock to reflect the package name change

## Test plan
- [x] Verify project builds with `cargo build`
- [x] Confirm binary name matches new package name
- [x] Run tests to ensure functionality remains intact

🤖 Generated with [Claude Code](https://claude.ai/code)