### PR TITLE
Remove --global flag from switch command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,12 +13,12 @@ git-profile-rs is a Rust CLI tool for managing Git profiles. It allows users to 
 - **Profile Module**: `src/profile/` contains profile management functionality
   - `src/profile/switch.rs`: Core switching logic using git2 to modify Git configuration
 
-The tool modifies Git configuration by adding include paths to either local repository config (default) or global Git config (with --global flag).
+The tool modifies Git configuration by adding include paths to the local repository config.
 
 ## Development Commands
 
 - **Build**: `cargo build`
-- **Run**: `cargo run -- switch <PROFILE-NAME> [--global]`
+- **Run**: `cargo run -- switch <PROFILE-NAME>`
 - **Check code**: `cargo clippy`
 - **Check formatting**: `cargo fmt --check` (run before committing)
 - **Run tests**: `cargo test`

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -14,9 +14,6 @@ pub enum Commands {
     Switch {
         /// Profile name to switch to
         profile_name: String,
-        /// Apply globally instead of locally
-        #[arg(long, short)]
-        global: bool,
     },
     /// List available git profiles
     List {

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,28 +14,16 @@ fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
     let profile_dir = ConfigDirGitProfile::new()?;
     match cli.command {
-        Commands::Switch {
-            profile_name,
-            global,
-        } => switch(&profile_name, global, &profile_dir)?,
+        Commands::Switch { profile_name } => switch(&profile_name, &profile_dir)?,
         Commands::List { verbose } => list(verbose, &profile_dir)?,
     }
     Ok(())
 }
 
-fn switch(profile_name: &str, global: bool, profile_dir: &impl ConfigDir) -> anyhow::Result<()> {
-    let open_config = if global {
-        GitConfigGit2::open_global
-    } else {
-        GitConfigGit2::open_local
-    };
-    let mut config = open_config().with_context(|| {
-        format!(
-            "Failed to open {} git configuration",
-            if global { "global" } else { "local" }
-        )
-    })?;
-    profile::switch::switch(profile_name, global, profile_dir, &mut config)
+fn switch(profile_name: &str, profile_dir: &impl ConfigDir) -> anyhow::Result<()> {
+    let mut config =
+        GitConfigGit2::open_local().with_context(|| "Failed to open local git configuration")?;
+    profile::switch::switch(profile_name, profile_dir, &mut config)
         .with_context(|| format!("Failed to switch to profile '{}'", profile_name))?;
     Ok(())
 }

--- a/src/profile/switch.rs
+++ b/src/profile/switch.rs
@@ -4,7 +4,6 @@ use crate::profile::error::GitProfileError;
 
 pub fn switch<T: GitConfig, U: ConfigDir>(
     profile_name: &str,
-    global: bool,
     profile_dir: &U,
     config: &mut T,
 ) -> anyhow::Result<()> {
@@ -21,11 +20,7 @@ pub fn switch<T: GitConfig, U: ConfigDir>(
         }
     }
     config.add_include_path(&profile_path)?;
-    if global {
-        println!("Global git profile switched to: {}", profile_name);
-    } else {
-        println!("Local git profile switched to: {}", profile_name);
-    }
+    println!("Git profile switched to: {}", profile_name);
     Ok(())
 }
 
@@ -112,23 +107,11 @@ mod tests {
     fn test_switch_with_mock_config() {
         let mut mock_config = MockGitConfig::new();
         let mock_profile_dir = MockGitProfileDir::new("/test/config/git-profile");
-        let result = switch("testprofile", false, &mock_profile_dir, &mut mock_config);
+        let result = switch("testprofile", &mock_profile_dir, &mut mock_config);
         assert!(result.is_ok());
         assert_eq!(
             mock_config.get("include.path"),
             Some(&"/test/config/git-profile/testprofile.gitconfig".to_string())
-        );
-    }
-
-    #[test]
-    fn test_switch_global_flag() {
-        let mut mock_config = MockGitConfig::new();
-        let mock_profile_dir = MockGitProfileDir::new("/test/config/git-profile");
-        let result = switch("globalprofile", true, &mock_profile_dir, &mut mock_config);
-        assert!(result.is_ok());
-        assert_eq!(
-            mock_config.get("include.path"),
-            Some(&"/test/config/git-profile/globalprofile.gitconfig".to_string())
         );
     }
 
@@ -160,7 +143,7 @@ mod tests {
         mock_config
             .include_paths
             .push("/another/config.gitconfig".to_string());
-        let result = switch("work", false, &mock_profile_dir, &mut mock_config);
+        let result = switch("work", &mock_profile_dir, &mut mock_config);
         assert!(result.is_ok());
         // Check that other includes are preserved
         let paths = mock_config.get_include_paths().unwrap();
@@ -181,7 +164,7 @@ mod tests {
         mock_config
             .include_paths
             .push("/home/user/.config/git-profile/personal.gitconfig".to_string());
-        let result = switch("work", false, &mock_profile_dir, &mut mock_config);
+        let result = switch("work", &mock_profile_dir, &mut mock_config);
         assert!(result.is_ok());
         // Check that the old git-profile include is replaced
         let paths = mock_config.get_include_paths().unwrap();
@@ -196,42 +179,27 @@ mod tests {
         let mock_profile_dir = MockGitProfileDir::new("/test/config");
 
         // Test empty profile name
-        let result = switch("", false, &mock_profile_dir, &mut mock_config);
+        let result = switch("", &mock_profile_dir, &mut mock_config);
         assert!(result.is_err());
 
         // Test profile name with forward slash
-        let result = switch(
-            "invalid/profile",
-            false,
-            &mock_profile_dir,
-            &mut mock_config,
-        );
+        let result = switch("invalid/profile", &mock_profile_dir, &mut mock_config);
         assert!(result.is_err());
 
         // Test profile name with backslash
-        let result = switch(
-            "invalid\\profile",
-            false,
-            &mock_profile_dir,
-            &mut mock_config,
-        );
+        let result = switch("invalid\\profile", &mock_profile_dir, &mut mock_config);
         assert!(result.is_err());
 
         // Test profile name with null character
-        let result = switch(
-            "invalid\0profile",
-            false,
-            &mock_profile_dir,
-            &mut mock_config,
-        );
+        let result = switch("invalid\0profile", &mock_profile_dir, &mut mock_config);
         assert!(result.is_err());
 
         // Test "." as profile name
-        let result = switch(".", false, &mock_profile_dir, &mut mock_config);
+        let result = switch(".", &mock_profile_dir, &mut mock_config);
         assert!(result.is_err());
 
         // Test ".." as profile name
-        let result = switch("..", false, &mock_profile_dir, &mut mock_config);
+        let result = switch("..", &mock_profile_dir, &mut mock_config);
         assert!(result.is_err());
     }
 }


### PR DESCRIPTION
## Summary
• Remove --global flag from switch command to focus on local repository configuration
• Simplify CLI interface by removing an edge case that most users don't need
• Prevent accidental global configuration changes that would affect all repositories

## Motivation
As discussed in #20, the `--global` flag goes against the core purpose of git-profile, which is to manage different Git configurations per project/repository. Global profile switching would affect all repositories system-wide, which is typically not the desired behavior.

## Changes
- Remove `global` flag from Switch command in CLI definition
- Update switch functions to only work with local repository config
- Remove all global-related logic and conditional messages  
- Remove `test_switch_global_flag` test case
- Update documentation to reflect local-only operation

## Test plan
- [x] All existing tests pass (minus the removed global flag test)
- [x] Manual testing confirms switch command works for local repos only
- [x] Attempting to use --global flag now shows appropriate error
- [ ] Code review
- [ ] No regression in local profile switching functionality

Fixes #20

🤖 Generated with [Claude Code](https://claude.ai/code)