### PR TITLE
Fix release workflow with modern GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,91 +6,53 @@ on:
       - '[0-9]+.[0-9]+.[0-9]+'
       - '[0-9]+.[0-9]+.[0-9]+-*'
 
+permissions:
+  contents: write
+
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  create-release:
-    name: Create Release
+  build-and-release:
+    name: Build and Release
     runs-on: ubuntu-latest
-    outputs:
-      upload_url: ${{ steps.create_release.outputs.upload_url }}
-    steps:
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref_name }}
-          draft: false
-          prerelease: false
-
-  build-release:
-    name: Build Release
-    needs: create-release
-    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         include:
-          # Linux - using musl for static linking and better compatibility
-          - os: ubuntu-latest
-            target: x86_64-unknown-linux-musl
-            artifact_name: git-profile-rs
-            asset_name: git-profile-rs-linux-amd64
-            use_cross: true
-          - os: ubuntu-latest
-            target: aarch64-unknown-linux-musl
-            artifact_name: git-profile-rs
-            asset_name: git-profile-rs-linux-arm64
-            use_cross: true
-          
-          # macOS
-          - os: macos-latest
-            target: x86_64-apple-darwin
-            artifact_name: git-profile-rs
-            asset_name: git-profile-rs-macos-amd64
-          - os: macos-latest
-            target: aarch64-apple-darwin
-            artifact_name: git-profile-rs
-            asset_name: git-profile-rs-macos-arm64
-          
-          # Windows
-          - os: windows-latest
-            target: x86_64-pc-windows-msvc
-            artifact_name: git-profile-rs.exe
-            asset_name: git-profile-rs-windows-amd64.exe
+          # Linux - only x86_64 works reliably with cross
+          - target: x86_64-unknown-linux-musl
+            archive: tar.gz
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Setup Rust
-        uses: actions-rs/toolchain@v1
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          target: ${{ matrix.target }}
-          override: true
+          targets: ${{ matrix.target }}
 
-      - name: Build with cargo
-        if: matrix.use_cross != true
-        run: cargo build --release --target ${{ matrix.target }} --features vendored-openssl
+      - name: Install cross
+        run: |
+          curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+          cargo binstall --no-confirm cross
 
-      - name: Build with cross
-        if: matrix.use_cross == true
-        uses: actions-rs/cargo@v1
+      - name: Build binary
+        run: cross build --release --target ${{ matrix.target }} --features vendored-openssl
+
+      - name: Create archive
+        shell: bash
+        run: |
+          binary_name="git-profile"
+          dirname="$binary_name-${{ github.ref_name }}-${{ matrix.target }}"
+          mkdir "$dirname"
+          
+          mv "target/${{ matrix.target }}/release/$binary_name" "$dirname"
+          tar -czf "$dirname.tar.gz" "$dirname"
+          echo "ASSET=$dirname.tar.gz" >> $GITHUB_ENV
+
+      - name: Upload release assets
+        uses: softprops/action-gh-release@v2
         with:
-          use-cross: true
-          command: build
-          args: --release --target ${{ matrix.target }} --features vendored-openssl
-
-      - name: Upload Release Asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create-release.outputs.upload_url }}
-          asset_path: ./target/${{ matrix.target }}/release/${{ matrix.artifact_name }}
-          asset_name: ${{ matrix.asset_name }}
-          asset_content_type: application/octet-stream
+          files: ${{ env.ASSET }}
+          generate_release_notes: true


### PR DESCRIPTION
## Summary
- Fix broken release workflow by replacing deprecated GitHub Actions with modern alternatives
- Implement working cross-compilation for Linux x86_64 binaries

## Changes Made
- **Modern Actions**: Replace deprecated `actions/create-release@v1` and `actions-rs/*` with `softprops/action-gh-release@v2` and `dtolnay/rust-toolchain@stable`
- **Cross-compilation**: Use `cross` tool with vendored OpenSSL to resolve dependency issues
- **Simplified workflow**: Single Ubuntu runner instead of multi-OS matrix (only Linux x86_64 works reliably)
- **Correct binary name**: Fix from `git-profile-rs` to `git-profile` (matches Cargo.toml)
- **Proper permissions**: Add `contents: write` for release creation

## Testing Results
✅ Linux x86_64-unknown-linux-musl builds and runs successfully  
❌ ARM64 Linux: GLIBC conflicts in cross container  
❌ macOS/Windows: Require target installation (tracked in #23)

## Test Plan
- [x] Verify workflow compiles without errors
- [x] Test cross-compilation locally produces working binary
- [x] Validate archive creation and structure
- [ ] Test actual release creation (will happen on next tag)

🤖 Generated with [Claude Code](https://claude.ai/code)