### PR TITLE
Fix profile switching when no include.path exists in git config

### DIFF
--- a/src/profile/git_config_git2.rs
+++ b/src/profile/git_config_git2.rs
@@ -29,10 +29,11 @@ impl GitConfig for GitConfigGit2 {
 
     fn get_include_paths(&self) -> Result<Vec<String>, GitProfileError> {
         let mut paths = Vec::new();
-        let mut entries = self
-            .config
-            .entries(Some("include.path"))
-            .map_err(GitProfileError::ConfigAccess)?;
+        let mut entries = match self.config.entries(Some("include.path")) {
+            Ok(entries) => entries,
+            Err(e) if e.code() == git2::ErrorCode::NotFound => return Ok(paths),
+            Err(e) => return Err(GitProfileError::ConfigAccess(e)),
+        };
         while let Some(entry) = entries.next() {
             match entry {
                 Ok(entry) => {


### PR DESCRIPTION
## Summary
- Fix NotFound error when switching profiles in a repository that has no existing include.path entries
- Handle the git2::ErrorCode::NotFound case gracefully by returning an empty vector instead of propagating the error

## Test plan
- [x] Test switching profiles in a fresh repository with no existing include.path entries
- [x] Verify that profile switching still works correctly when include.path entries already exist
- [x] Confirm that error handling preserves other git2 error types appropriately

🤖 Generated with [Claude Code](https://claude.ai/code)