### PR TITLE
Fix data-loss include removal, silent failures, and add missing tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 
-on: push
+on:
+  push:
+  pull_request:
 
 env:
   CARGO_TERM_COLOR: always
@@ -25,7 +27,7 @@ jobs:
       - name: Run tests
         run: cargo test
       - name: Check code with clippy
-        run: cargo clippy -- -D warnings
+        run: cargo clippy --all-targets -- -D warnings
       - name: Check formatting
         run: cargo fmt --check
       - name: Build release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,6 +139,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -166,6 +182,7 @@ dependencies = [
  "anyhow",
  "clap",
  "git2",
+ "tempfile",
  "thiserror",
 ]
 
@@ -315,9 +332,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libgit2-sys"
@@ -360,6 +377,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -370,6 +393,12 @@ name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -451,6 +480,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -514,6 +556,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,9 @@ name = "git-profile"
 version = "0.1.0"
 edition = "2021"
 
+[lints.clippy]
+uninlined_format_args = "warn"
+
 [dependencies]
 anyhow = "1.0"
 clap = { version = "4.5.39", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,9 @@ clap = { version = "4.5.39", features = ["derive"] }
 git2 = "0.20.2"
 thiserror = "1.0"
 
+[dev-dependencies]
+tempfile = "3"
+
 [features]
 default = []
 vendored-openssl = ["git2/vendored-openssl"]

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ This project is primarily AI-generated and created for testing purposes. The aut
 # 2. Create a profile
 mkdir -p ~/.config/git-profile
 echo '[user]
-    name = "Your Name"
-    email = "your.email@example.com"' > ~/.config/git-profile/work.gitconfig
+    name = Your Name
+    email = your.email@example.com' > ~/.config/git-profile/work.gitconfig
 # 3. Switch to profile in current repo
 git-profile switch work
 ```
@@ -49,27 +49,20 @@ cargo install git-profile
 ## Usage
 
 You need to prepare for a *git profile* first.
-Your profiles are placed on `$XDG_CONFIG/git-profile/<PROFILE-NAME>.gitconfig`.
+Your profiles are placed on `$XDG_CONFIG_HOME/git-profile/<PROFILE-NAME>.gitconfig`.
 
 The following command will switch the *git profile*.
 
 ```bash
-git-profile switch <PROFILE-NAME> [--global]
+git-profile switch <PROFILE-NAME>
 ```
 
-### Local vs Global Configuration
-
-- **Without `--global`**: The profile is applied only to the current repository by modifying `.git/config`. This is useful when you want different identities for different projects.
-- **With `--global`**: The profile is applied system-wide by modifying your global Git configuration (`~/.gitconfig`). All repositories will use this profile unless overridden by local configuration.
-
-Note: Local repository configuration always takes precedence over global configuration.
-
 This command will write down the following line in the configuration file.
-Note that `$XDG_CONFIG` will be resolved on `.git/config` because of the restriction of Git.
+Note that `$XDG_CONFIG_HOME` will be resolved on `.git/config` because of the restriction of Git.
 
 ```gitconfig
 [include]
-	path = <$XDG_CONFIG>/git-profile/<PROFILE-NAME>.gitconfig
+	path = <$XDG_CONFIG_HOME>/git-profile/<PROFILE-NAME>.gitconfig
 ```
 
 ### Verifying Active Profile
@@ -85,14 +78,10 @@ git config user.name
 git config user.email
 ```
 
-To see if a profile is set locally or globally:
+To check the local repository config:
 
 ```bash
-# Check local repository config
 git config --local --get-regexp include.path
-
-# Check global config
-git config --global --get-regexp include.path
 ```
 
 ## Sample Profile

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,6 +3,7 @@ use clap::{Parser, Subcommand};
 #[derive(Parser, Debug)]
 #[command(name = "git-profile")]
 #[command(about = "A Rust implementation for Git Profile management")]
+#[command(version)]
 pub struct Cli {
     #[command(subcommand)]
     pub command: Commands,

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,8 +24,8 @@ fn switch(profile_name: &str, profile_dir: &impl ConfigDir) -> anyhow::Result<()
     let mut config =
         GitConfigGit2::open().with_context(|| "Failed to open local git configuration")?;
     profile::switch::switch(profile_name, profile_dir, &mut config)
-        .with_context(|| format!("Failed to switch to profile '{}'", profile_name))?;
-    println!("Git profile switched to: {}", profile_name);
+        .with_context(|| format!("Failed to switch to profile '{profile_name}'"))?;
+    println!("Git profile switched to: {profile_name}");
     Ok(())
 }
 
@@ -36,9 +36,9 @@ fn list(verbose: bool, profile_dir: &impl ConfigDir) -> anyhow::Result<()> {
     for (name, path, is_current) in profiles {
         let marker = if is_current { "* " } else { "  " };
         if verbose {
-            println!("{}{} -> {}", marker, name, path);
+            println!("{marker}{name} -> {path}");
         } else {
-            println!("{}{}", marker, name);
+            println!("{marker}{name}");
         }
     }
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,7 @@ fn switch(profile_name: &str, profile_dir: &impl ConfigDir) -> anyhow::Result<()
         GitConfigGit2::open().with_context(|| "Failed to open local git configuration")?;
     profile::switch::switch(profile_name, profile_dir, &mut config)
         .with_context(|| format!("Failed to switch to profile '{}'", profile_name))?;
+    println!("Git profile switched to: {}", profile_name);
     Ok(())
 }
 

--- a/src/profile/config_dir_git_profile.rs
+++ b/src/profile/config_dir_git_profile.rs
@@ -8,15 +8,9 @@ pub struct ConfigDirGitProfile {
 
 impl ConfigDirGitProfile {
     pub fn new() -> Result<Self, GitProfileError> {
-        let xdg_config = if let Ok(xdg_config) = std::env::var("XDG_CONFIG_HOME") {
-            xdg_config
-        } else {
-            let home = std::env::var("HOME").map_err(|_| GitProfileError::Environment {
-                variable: "HOME".to_string(),
-            })?;
-            format!("{}/.config", home)
-        };
-        let path = PathBuf::from(format!("{}/git-profile", xdg_config));
+        let xdg_config_home = std::env::var("XDG_CONFIG_HOME").ok();
+        let home = std::env::var("HOME").ok();
+        let path = resolve_profile_dir(xdg_config_home, home)?;
         Ok(ConfigDirGitProfile { path })
     }
 }
@@ -24,5 +18,58 @@ impl ConfigDirGitProfile {
 impl ConfigDir for ConfigDirGitProfile {
     fn path(&self) -> PathBuf {
         self.path.clone()
+    }
+}
+
+fn resolve_profile_dir(
+    xdg_config_home: Option<String>,
+    home: Option<String>,
+) -> Result<PathBuf, GitProfileError> {
+    let config_dir = match xdg_config_home {
+        Some(xdg_config_home) if !xdg_config_home.is_empty() => PathBuf::from(xdg_config_home),
+        _ => {
+            let home = home.ok_or_else(|| GitProfileError::Environment {
+                variable: "HOME".to_string(),
+            })?;
+            PathBuf::from(home).join(".config")
+        }
+    };
+    Ok(config_dir.join("git-profile"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn xdg_config_home_set_and_non_empty_is_used_as_is() {
+        let path = resolve_profile_dir(
+            Some("/custom/xdg".to_string()),
+            Some("/home/user".to_string()),
+        )
+        .unwrap();
+        assert_eq!(path, PathBuf::from("/custom/xdg/git-profile"));
+    }
+
+    #[test]
+    fn xdg_config_home_unset_falls_back_to_home_config() {
+        let path = resolve_profile_dir(None, Some("/home/user".to_string())).unwrap();
+        assert_eq!(path, PathBuf::from("/home/user/.config/git-profile"));
+    }
+
+    #[test]
+    fn xdg_config_home_empty_falls_back_to_home_config() {
+        let path =
+            resolve_profile_dir(Some(String::new()), Some("/home/user".to_string())).unwrap();
+        assert_eq!(path, PathBuf::from("/home/user/.config/git-profile"));
+    }
+
+    #[test]
+    fn both_unset_returns_environment_error() {
+        let result = resolve_profile_dir(None, None);
+        assert!(matches!(
+            result,
+            Err(GitProfileError::Environment { variable }) if variable == "HOME"
+        ));
     }
 }

--- a/src/profile/error.rs
+++ b/src/profile/error.rs
@@ -3,8 +3,8 @@ use thiserror::Error;
 /// Errors that can occur in git-profile-rs
 #[derive(Error, Debug)]
 pub enum GitProfileError {
-    #[error("Failed to open git repository: {0}")]
-    RepositoryOpen(#[from] git2::Error),
+    #[error("Failed to open git repository")]
+    RepositoryOpen(#[source] git2::Error),
 
     #[error("Failed to access git configuration")]
     ConfigAccess(#[source] git2::Error),

--- a/src/profile/error.rs
+++ b/src/profile/error.rs
@@ -12,8 +12,11 @@ pub enum GitProfileError {
     #[error("Environment variable error: {variable}")]
     Environment { variable: String },
 
-    #[error("Profile path error: {path}")]
+    #[error("Invalid profile name: {path}")]
     ProfilePath { path: String },
+
+    #[error("Profile '{name}' not found at {path}")]
+    ProfileNotFound { name: String, path: String },
 
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),

--- a/src/profile/git_config_git2.rs
+++ b/src/profile/git_config_git2.rs
@@ -1,6 +1,6 @@
 use crate::git_config::GitConfig;
 use crate::profile::error::GitProfileError;
-use git2::{Config, Repository};
+use git2::{Config, ConfigLevel, Repository};
 
 pub struct GitConfigGit2 {
     config: Config,
@@ -8,14 +8,18 @@ pub struct GitConfigGit2 {
 
 impl GitConfigGit2 {
     pub fn open() -> Result<Self, GitProfileError> {
-        let repo = Repository::open(".")?;
+        let repo = Repository::discover(".").map_err(GitProfileError::RepositoryOpen)?;
         let config = repo.config().map_err(GitProfileError::ConfigAccess)?;
+        let config = config
+            .open_level(ConfigLevel::Local)
+            .map_err(GitProfileError::ConfigAccess)?;
         Ok(GitConfigGit2 { config })
     }
 
     pub fn open_optional() -> Option<Self> {
-        let repo = Repository::open(".").ok()?;
+        let repo = Repository::discover(".").ok()?;
         let config = repo.config().ok()?;
+        let config = config.open_level(ConfigLevel::Local).ok()?;
         Some(GitConfigGit2 { config })
     }
 }
@@ -28,8 +32,9 @@ impl GitConfig for GitConfigGit2 {
     }
 
     fn remove_include_path(&mut self, path: &str) -> Result<(), GitProfileError> {
+        let pattern = format!("^{}$", escape_regex(path));
         self.config
-            .remove_multivar("include.path", path)
+            .remove_multivar("include.path", &pattern)
             .map_err(GitProfileError::ConfigAccess)
     }
 
@@ -51,5 +56,83 @@ impl GitConfig for GitConfigGit2 {
             }
         }
         Ok(paths)
+    }
+}
+
+fn escape_regex(path: &str) -> String {
+    let mut escaped = String::with_capacity(path.len());
+    for c in path.chars() {
+        if matches!(
+            c,
+            '\\' | '.' | '+' | '*' | '?' | '(' | ')' | '[' | ']' | '{' | '}' | '|' | '^' | '$'
+        ) {
+            escaped.push('\\');
+        }
+        escaped.push(c);
+    }
+    escaped
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn new_test_config() -> (tempfile::TempDir, GitConfigGit2) {
+        let dir = tempfile::tempdir().expect("failed to create temp dir");
+        let repo = git2::Repository::init(dir.path()).expect("failed to init repo");
+        let config = repo.config().expect("failed to get repo config");
+        let config = config
+            .open_level(ConfigLevel::Local)
+            .expect("failed to open local config");
+        (dir, GitConfigGit2 { config })
+    }
+
+    #[test]
+    fn add_and_get_include_path_round_trip() {
+        let (_dir, mut config) = new_test_config();
+        config.add_include_path("/a/b/work.gitconfig").unwrap();
+        let paths = config.get_include_paths().unwrap();
+        assert_eq!(paths, vec!["/a/b/work.gitconfig".to_string()]);
+    }
+
+    #[test]
+    fn remove_include_path_removes_added_path() {
+        let (_dir, mut config) = new_test_config();
+        config.add_include_path("/a/b/work.gitconfig").unwrap();
+        config.remove_include_path("/a/b/work.gitconfig").unwrap();
+        let paths = config.get_include_paths().unwrap();
+        assert!(paths.is_empty());
+    }
+
+    #[test]
+    fn remove_include_path_does_not_remove_unrelated_substring_match() {
+        let (_dir, mut config) = new_test_config();
+        config
+            .add_include_path("/backup/a/b/work.gitconfig")
+            .unwrap();
+        config.add_include_path("/a/b/work.gitconfig").unwrap();
+        config.remove_include_path("/a/b/work.gitconfig").unwrap();
+        let paths = config.get_include_paths().unwrap();
+        assert_eq!(paths, vec!["/backup/a/b/work.gitconfig".to_string()]);
+    }
+
+    #[test]
+    fn get_include_paths_returns_empty_when_none_set() {
+        let (_dir, config) = new_test_config();
+        let paths = config.get_include_paths().unwrap();
+        assert!(paths.is_empty());
+    }
+
+    #[test]
+    fn remove_include_path_with_regex_metacharacters() {
+        let (_dir, mut config) = new_test_config();
+        config
+            .add_include_path("/a/dir+name/pro(file).gitconfig")
+            .unwrap();
+        config
+            .remove_include_path("/a/dir+name/pro(file).gitconfig")
+            .unwrap();
+        let paths = config.get_include_paths().unwrap();
+        assert!(paths.is_empty());
     }
 }

--- a/src/profile/list.rs
+++ b/src/profile/list.rs
@@ -15,12 +15,12 @@ pub fn list_profiles(
         .transpose()?
         .unwrap_or_default();
     let entries = fs::read_dir(profile_dir).map_err(|e| {
-        GitProfileError::ConfigError(format!("Failed to read profile directory: {}", e))
+        GitProfileError::ConfigError(format!("Failed to read profile directory: {e}"))
     })?;
     let mut profiles = Vec::new();
     for entry in entries {
         let entry = entry.map_err(|e| {
-            GitProfileError::ConfigError(format!("Failed to read directory entry: {}", e))
+            GitProfileError::ConfigError(format!("Failed to read directory entry: {e}"))
         })?;
         if let Some(profile) = process_profile_entry(entry.path(), &current_include_paths) {
             profiles.push(profile);

--- a/src/profile/list.rs
+++ b/src/profile/list.rs
@@ -42,6 +42,93 @@ fn process_profile_entry(
     }
     let name = path.file_stem()?.to_str()?.to_string();
     let path_string = path.to_string_lossy().to_string();
-    let is_current = current_include_paths.contains(&path_string);
+    let normalized_path = path_string.replace('\\', "/");
+    let is_current = current_include_paths
+        .iter()
+        .any(|include_path| include_path.replace('\\', "/") == normalized_path);
     Some((name, path_string, is_current))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct MockGitConfig {
+        include_paths: Vec<String>,
+    }
+
+    impl GitConfig for MockGitConfig {
+        fn add_include_path(&mut self, path: &str) -> Result<(), GitProfileError> {
+            self.include_paths.push(path.to_string());
+            Ok(())
+        }
+
+        fn remove_include_path(&mut self, path: &str) -> Result<(), GitProfileError> {
+            self.include_paths.retain(|p| p != path);
+            Ok(())
+        }
+
+        fn get_include_paths(&self) -> Result<Vec<String>, GitProfileError> {
+            Ok(self.include_paths.clone())
+        }
+    }
+
+    #[test]
+    fn test_list_profiles_returns_sorted_gitconfig_files() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("beta.gitconfig"), "").unwrap();
+        fs::write(dir.path().join("alpha.gitconfig"), "").unwrap();
+        fs::write(dir.path().join("notes.txt"), "").unwrap();
+        fs::create_dir(dir.path().join("sub.gitconfig")).unwrap();
+        let profiles = list_profiles(dir.path(), None::<&MockGitConfig>).unwrap();
+        let names: Vec<&str> = profiles.iter().map(|p| p.0.as_str()).collect();
+        assert_eq!(names, vec!["alpha", "beta"]);
+    }
+
+    #[test]
+    fn test_is_current_matches_include_path() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("alpha.gitconfig"), "").unwrap();
+        fs::write(dir.path().join("beta.gitconfig"), "").unwrap();
+        let alpha_path = dir.path().join("alpha.gitconfig");
+        let config = MockGitConfig {
+            include_paths: vec![alpha_path.to_string_lossy().to_string()],
+        };
+        let profiles = list_profiles(dir.path(), Some(&config)).unwrap();
+        let alpha = profiles.iter().find(|p| p.0 == "alpha").unwrap();
+        let beta = profiles.iter().find(|p| p.0 == "beta").unwrap();
+        assert!(alpha.2);
+        assert!(!beta.2);
+    }
+
+    #[test]
+    fn test_list_profiles_with_no_config_marks_none_current() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("alpha.gitconfig"), "").unwrap();
+        fs::write(dir.path().join("beta.gitconfig"), "").unwrap();
+        let profiles = list_profiles(dir.path(), None::<&MockGitConfig>).unwrap();
+        assert!(profiles.iter().all(|p| !p.2));
+    }
+
+    #[test]
+    fn test_list_profiles_returns_empty_for_missing_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing_dir = dir.path().join("does-not-exist");
+        let profiles = list_profiles(&missing_dir, None::<&MockGitConfig>).unwrap();
+        assert!(profiles.is_empty());
+    }
+
+    #[test]
+    fn test_is_current_normalizes_backslashes() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("alpha.gitconfig"), "").unwrap();
+        let alpha_path = dir.path().join("alpha.gitconfig");
+        let forward_slash_path = alpha_path.to_string_lossy().replace('\\', "/");
+        let config = MockGitConfig {
+            include_paths: vec![forward_slash_path],
+        };
+        let profiles = list_profiles(dir.path(), Some(&config)).unwrap();
+        let alpha = profiles.iter().find(|p| p.0 == "alpha").unwrap();
+        assert!(alpha.2);
+    }
 }

--- a/src/profile/switch.rs
+++ b/src/profile/switch.rs
@@ -8,13 +8,18 @@ pub fn switch<T: GitConfig, U: ConfigDir>(
     config: &mut T,
 ) -> anyhow::Result<()> {
     validate_profile_name(profile_name)?;
-    let raw_profile_path = format!(
-        "{}/{}.gitconfig",
-        profile_dir.path().display(),
-        profile_name
-    );
+    let profile_path_buf = profile_dir
+        .path()
+        .join(format!("{}.gitconfig", profile_name));
+    if !profile_path_buf.exists() {
+        return Err(GitProfileError::ProfileNotFound {
+            name: profile_name.to_string(),
+            path: profile_path_buf.display().to_string(),
+        }
+        .into());
+    }
     // Convert Windows backslashes to forward slashes for Git include path compatibility
-    let profile_path = raw_profile_path.replace("\\", "/");
+    let profile_path = profile_path_buf.display().to_string().replace("\\", "/");
     let existing_paths = config.get_include_paths()?;
     for path in &existing_paths {
         if std::path::Path::new(path).starts_with(profile_dir.path()) {
@@ -22,7 +27,6 @@ pub fn switch<T: GitConfig, U: ConfigDir>(
         }
     }
     config.add_include_path(&profile_path)?;
-    println!("Git profile switched to: {}", profile_name);
     Ok(())
 }
 
@@ -54,9 +58,9 @@ mod tests {
     }
 
     impl MockGitProfileDir {
-        fn new(path: &str) -> Self {
+        fn new(path: &std::path::Path) -> Self {
             MockGitProfileDir {
-                path: std::path::PathBuf::from(path),
+                path: path.to_path_buf(),
             }
         }
     }
@@ -107,13 +111,22 @@ mod tests {
 
     #[test]
     fn test_switch_with_mock_config() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        std::fs::write(temp_dir.path().join("testprofile.gitconfig"), "").unwrap();
         let mut mock_config = MockGitConfig::new();
-        let mock_profile_dir = MockGitProfileDir::new("/test/config/git-profile");
+        let mock_profile_dir = MockGitProfileDir::new(temp_dir.path());
         let result = switch("testprofile", &mock_profile_dir, &mut mock_config);
         assert!(result.is_ok());
         assert_eq!(
             mock_config.get("include.path"),
-            Some(&"/test/config/git-profile/testprofile.gitconfig".to_string())
+            Some(
+                &temp_dir
+                    .path()
+                    .join("testprofile.gitconfig")
+                    .display()
+                    .to_string()
+                    .replace("\\", "/")
+            )
         );
     }
 
@@ -136,8 +149,10 @@ mod tests {
 
     #[test]
     fn test_switch_preserves_other_includes() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        std::fs::write(temp_dir.path().join("work.gitconfig"), "").unwrap();
         let mut mock_config = MockGitConfig::new();
-        let mock_profile_dir = MockGitProfileDir::new("/home/user/.config/git-profile");
+        let mock_profile_dir = MockGitProfileDir::new(temp_dir.path());
         // Set up existing includes
         mock_config
             .include_paths
@@ -152,33 +167,58 @@ mod tests {
         assert_eq!(paths.len(), 3);
         assert_eq!(paths[0], "/path/to/delta.gitconfig");
         assert_eq!(paths[1], "/another/config.gitconfig");
-        assert_eq!(paths[2], "/home/user/.config/git-profile/work.gitconfig");
+        assert_eq!(
+            paths[2],
+            temp_dir
+                .path()
+                .join("work.gitconfig")
+                .display()
+                .to_string()
+                .replace("\\", "/")
+        );
     }
 
     #[test]
     fn test_switch_replaces_previous_git_profile() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        std::fs::write(temp_dir.path().join("work.gitconfig"), "").unwrap();
+        std::fs::write(temp_dir.path().join("personal.gitconfig"), "").unwrap();
         let mut mock_config = MockGitConfig::new();
-        let mock_profile_dir = MockGitProfileDir::new("/home/user/.config/git-profile");
+        let mock_profile_dir = MockGitProfileDir::new(temp_dir.path());
         // Set up existing includes including a git-profile one
         mock_config
             .include_paths
             .push("/path/to/delta.gitconfig".to_string());
-        mock_config
-            .include_paths
-            .push("/home/user/.config/git-profile/personal.gitconfig".to_string());
+        mock_config.include_paths.push(
+            temp_dir
+                .path()
+                .join("personal.gitconfig")
+                .display()
+                .to_string()
+                .replace("\\", "/"),
+        );
         let result = switch("work", &mock_profile_dir, &mut mock_config);
         assert!(result.is_ok());
         // Check that the old git-profile include is replaced
         let paths = mock_config.get_include_paths().unwrap();
         assert_eq!(paths.len(), 2);
         assert_eq!(paths[0], "/path/to/delta.gitconfig");
-        assert_eq!(paths[1], "/home/user/.config/git-profile/work.gitconfig");
+        assert_eq!(
+            paths[1],
+            temp_dir
+                .path()
+                .join("work.gitconfig")
+                .display()
+                .to_string()
+                .replace("\\", "/")
+        );
     }
 
     #[test]
     fn test_switch_with_invalid_profile_names() {
+        let temp_dir = tempfile::tempdir().unwrap();
         let mut mock_config = MockGitConfig::new();
-        let mock_profile_dir = MockGitProfileDir::new("/test/config");
+        let mock_profile_dir = MockGitProfileDir::new(temp_dir.path());
 
         // Test empty profile name
         let result = switch("", &mock_profile_dir, &mut mock_config);
@@ -203,5 +243,21 @@ mod tests {
         // Test ".." as profile name
         let result = switch("..", &mock_profile_dir, &mut mock_config);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_switch_with_nonexistent_profile_returns_error() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let mut mock_config = MockGitConfig::new();
+        let mock_profile_dir = MockGitProfileDir::new(temp_dir.path());
+        mock_config
+            .include_paths
+            .push("/path/to/delta.gitconfig".to_string());
+        let result = switch("missing", &mock_profile_dir, &mut mock_config);
+        assert!(result.is_err());
+        // Include paths must remain unchanged
+        let paths = mock_config.get_include_paths().unwrap();
+        assert_eq!(paths.len(), 1);
+        assert_eq!(paths[0], "/path/to/delta.gitconfig");
     }
 }

--- a/src/profile/switch.rs
+++ b/src/profile/switch.rs
@@ -8,9 +8,7 @@ pub fn switch<T: GitConfig, U: ConfigDir>(
     config: &mut T,
 ) -> anyhow::Result<()> {
     validate_profile_name(profile_name)?;
-    let profile_path_buf = profile_dir
-        .path()
-        .join(format!("{}.gitconfig", profile_name));
+    let profile_path_buf = profile_dir.path().join(format!("{profile_name}.gitconfig"));
     if !profile_path_buf.exists() {
         return Err(GitProfileError::ProfileNotFound {
             name: profile_name.to_string(),


### PR DESCRIPTION
## Summary

Fixes the issues found in a project-wide diagnostic review. All bugs below were reproduced before fixing and re-verified end-to-end after.

### Bug fixes

- **Data loss: unrelated `include.path` entries could be deleted on `switch`** — `Config::remove_multivar` interprets its second argument as an unanchored POSIX ERE, so a profile path could match (and delete) unrelated include entries as a substring. Paths are now regex-escaped and anchored with `^...$`.
- **Silent failure when switching to a non-existent profile** — `switch nosuch` used to print success, write an include to a missing file (silently ignored by git), and remove the previously active profile. It now fails with `Profile 'nosuch' not found at <path>` before touching the config.
- **`switch`/`list` failed when run from a repository subdirectory** — `Repository::open(".")` replaced with `Repository::discover(".")`.
- **Global config interference** — the tool read the multi-level git config, so `list` marked includes from `~/.gitconfig` as the current profile and `switch` attempted to remove them. Reads/writes are now scoped to the local `.git/config` via `open_level(ConfigLevel::Local)`.
- **Empty `XDG_CONFIG_HOME` treated as valid** — `XDG_CONFIG_HOME=""` resolved the profile dir to `/git-profile`; it now falls back to `$HOME/.config` per the XDG Base Directory spec.
- **Windows current-profile detection** — `list` compared native (backslash) paths against the forward-slash paths written by `switch`; both sides are now normalized before comparison.

### Improvements

- `--version` flag support (release binaries previously had no way to report their version).
- Duplicated error message in the `RepositoryOpen` error chain removed; clearer wording for invalid profile names.
- `println!` moved out of the library layer into `main.rs`; path construction switched to `PathBuf::join`.
- README: removed the documented-but-unimplemented `--global` option, fixed quoted values in the Quick Start gitconfig example, corrected `$XDG_CONFIG` to `$XDG_CONFIG_HOME`.

### Tests

Test suite grew from 5 to 20 tests: integration tests for `GitConfigGit2` against real temp repositories (including a regression test for the data-loss bug), tests for `list_profiles` (previously untested), and tests for `XDG_CONFIG_HOME` resolution via a pure function (no env mutation).

### Note

A CI workflow improvement (`pull_request` trigger + `clippy --all-targets`) had to be excluded from this branch because the GitHub App lacks `workflows` permission. The patch is attached in a comment below for manual application.

## Verification

- `cargo test`: 20 passed
- `cargo clippy --all-targets -- -D warnings`: clean
- `cargo fmt --check`: clean
- All originally reproduced bug scenarios re-tested manually against the built binary.

https://claude.ai/code/session_01FNSbzXZoLsSb6u1ZnGzETW

---
_Generated by [Claude Code](https://claude.ai/code/session_01FNSbzXZoLsSb6u1ZnGzETW)_